### PR TITLE
feat: 선택한 영화들의 영화관 조회 기능 구현

### DIFF
--- a/src/main/java/org/collaboration/megabox/domain/controller/CinemaController.java
+++ b/src/main/java/org/collaboration/megabox/domain/controller/CinemaController.java
@@ -1,0 +1,40 @@
+package org.collaboration.megabox.domain.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.collaboration.megabox.domain.dto.response.CinemaListResponse;
+import org.collaboration.megabox.domain.service.CinemaService;
+import org.collaboration.megabox.global.common.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@Tag(name = "영화관 API", description = "영화관 관련 API입니다.")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/cinemas")
+public class CinemaController {
+
+    private final CinemaService cinemaService;
+
+    @Operation(
+            summary = "영화 영화관 리스트 조회",
+            description = """
+            선택한 영화들의 영화관을 조회하는 API입니다.
+            - RequestParam으로 movieIds(영화 ID 리스트)를 전달합니다.
+            """
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<CinemaListResponse>> getCinemas(
+            @RequestParam("movieIds")List<Long> movieIds
+    ) {
+        CinemaListResponse response = cinemaService.getCinemasByMovies(movieIds);
+        return ApiResponse.success(response);
+    }
+}

--- a/src/main/java/org/collaboration/megabox/domain/dto/response/CinemaListResponse.java
+++ b/src/main/java/org/collaboration/megabox/domain/dto/response/CinemaListResponse.java
@@ -1,0 +1,17 @@
+package org.collaboration.megabox.domain.dto.response;
+
+import org.collaboration.megabox.domain.entity.Cinema;
+
+import java.util.List;
+
+public record CinemaListResponse(
+        List<String> cinemas
+) {
+    public static CinemaListResponse from(List<Cinema> cinemas) {
+        return new CinemaListResponse(
+                cinemas.stream()
+                        .map(Cinema::getName)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/collaboration/megabox/domain/repository/CinemaRepository.java
+++ b/src/main/java/org/collaboration/megabox/domain/repository/CinemaRepository.java
@@ -1,0 +1,21 @@
+package org.collaboration.megabox.domain.repository;
+
+import org.collaboration.megabox.domain.entity.Cinema;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface CinemaRepository extends JpaRepository<Cinema, Long> {
+
+    @Query("""
+        SELECT DISTINCT c
+        FROM Cinema c
+            JOIN Theater t ON t.cinema = c
+            JOIN Showtime s ON s.theater = t
+        WHERE s.movie.movieId IN :movieIds
+        ORDER BY c.name ASC
+    """)
+    List<Cinema> findAllByMovieIds(@Param("movieIds") List<Long> movieIds);
+}

--- a/src/main/java/org/collaboration/megabox/domain/service/CinemaService.java
+++ b/src/main/java/org/collaboration/megabox/domain/service/CinemaService.java
@@ -1,0 +1,23 @@
+package org.collaboration.megabox.domain.service;
+
+import lombok.RequiredArgsConstructor;
+import org.collaboration.megabox.domain.dto.response.CinemaListResponse;
+import org.collaboration.megabox.domain.entity.Cinema;
+import org.collaboration.megabox.domain.repository.CinemaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class CinemaService {
+
+    private final CinemaRepository cinemaRepository;
+
+    public CinemaListResponse getCinemasByMovies(List<Long> movieIds) {
+        List<Cinema> cinemas = cinemaRepository.findAllByMovieIds(movieIds);
+        return CinemaListResponse.from(cinemas);
+    }
+}


### PR DESCRIPTION
## 📌 Related Issue
- closes #17

## #️⃣ 요약 설명
- 선택한 영화들의 영화관 조회 기능을 구현했습니다.
- Cinema 리소스에 대한 조회여서 SRP를 지키기 위해 CinemaCotroller/Service/Repository를 만들었습니다.

## 📝 작업 내용
<!-- 작은 단위의 작업들에 대해 작성해주세요 -->
- [x] 선택한 영화들의 영화관 조회 API 구현

## 👍 동작 확인
- swagger에서는 RequestParam을 multivalue로 전달한다고 하는데, postman으로 ","로 값들을 전달했을 때 정상 응답 확인했습니다.
<img width="496" height="470" alt="image" src="https://github.com/user-attachments/assets/c9db0efd-69be-4d85-a9f3-d4ba7ff58ce2" />
<img width="528" height="529" alt="image" src="https://github.com/user-attachments/assets/84707d68-4fd4-4816-ac00-54848d2da60b" />

## 💬 리뷰 요구사항(선택)
<!-- 트러블 슈팅이나 논의하고 싶은 내용에 대해 작성해주세요 -->
- 내용